### PR TITLE
CDPS-1394: Express 5 compatibility

### DIFF
--- a/server/middleware/asyncMiddleware.ts
+++ b/server/middleware/asyncMiddleware.ts
@@ -1,7 +1,0 @@
-import type { Request, Response, NextFunction, RequestHandler } from 'express'
-
-export default function asyncMiddleware(fn: RequestHandler) {
-  return (req: Request, res: Response, next: NextFunction): void => {
-    Promise.resolve(fn(req, res, next)).catch(next)
-  }
-}

--- a/server/middleware/authorisationMiddleware.ts
+++ b/server/middleware/authorisationMiddleware.ts
@@ -2,13 +2,12 @@ import { jwtDecode } from 'jwt-decode'
 import type { RequestHandler } from 'express'
 
 import logger from '../../logger'
-import asyncMiddleware from './asyncMiddleware'
 
 export default function authorisationMiddleware(
   authorisedRoles: string[] = [],
   redirect: boolean = true,
 ): RequestHandler {
-  return asyncMiddleware((req, res, next) => {
+  return (req, res, next) => {
     // authorities in the user token will always be prefixed by ROLE_.
     // Convert roles that are passed into this function without the prefix so that we match correctly.
     const authorisedAuthorities = authorisedRoles.map(role => (role.startsWith('ROLE_') ? role : `ROLE_${role}`))
@@ -27,5 +26,5 @@ export default function authorisationMiddleware(
 
     req.session.returnTo = req.originalUrl
     return res.redirect('/sign-in')
-  })
+  }
 }

--- a/server/routes/common/routes.ts
+++ b/server/routes/common/routes.ts
@@ -1,13 +1,12 @@
 import { RequestHandler, Router } from 'express'
-import asyncMiddleware from '../../middleware/asyncMiddleware'
 
 const BaseRouter = () => {
   const router = Router({ mergeParams: true })
 
   const get = (path: string, ...handlers: RequestHandler[]) =>
-    router.get(path, ...handlers.slice(0, -1), asyncMiddleware(handlers.slice(-1)[0]!))
+    router.get(path, ...handlers.slice(0, -1), handlers.slice(-1)[0]!)
   const post = (path: string, ...handlers: RequestHandler[]) =>
-    router.post(path, ...handlers.slice(0, -1), asyncMiddleware(handlers.slice(-1)[0]!))
+    router.post(path, ...handlers.slice(0, -1), handlers.slice(-1)[0]!)
 
   return {
     router,

--- a/server/routes/index.ts
+++ b/server/routes/index.ts
@@ -1,6 +1,5 @@
-import { RequestHandler, Router } from 'express'
+import { Router } from 'express'
 import { dataAccess } from '../data'
-import asyncMiddleware from '../middleware/asyncMiddleware'
 import AddAnyAlertRoutes from './add-any-alert/routes'
 import ManageReferenceDataRoutes from './manage-reference-data/routes'
 import insertJourneyIdentifier from '../middleware/insertJourneyIdentifier'
@@ -10,15 +9,14 @@ import { Services } from '../services'
 
 export default function routes(services: Services): Router {
   const router = Router()
-  const get = (path: string | string[], handler: RequestHandler) => router.get(path, asyncMiddleware(handler))
   const apiClient = dataAccess()
   const { alertsApiClient, prisonerSearchApiClient } = apiClient
 
-  get('/', async (_req, res) => {
+  router.get('/', async (_req, res) => {
     res.render('view', { roles: res.locals.user.userRoles })
   })
 
-  get('/error-page', (req, res) => {
+  router.get('/error-page', (req, res) => {
     const { errorMessage } = req.session
     res.render('pages/errorPage', { errorMessage })
   })


### PR DESCRIPTION
`asyncMiddleware` is not needed since express 5 can already deal with thrown exceptions inside request handlers. cf. [template project](https://github.com/ministryofjustice/hmpps-template-typescript/pull/560) removed it during the upgrade