### PR TITLE
Replace `uuid` library with standard library function

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -44,7 +44,6 @@
         "redis": "^5.12.1",
         "superagent": "^10.3.0",
         "url-value-parser": "^2.2.0",
-        "uuid": "^11.1.1",
         "zod": "^4.4.3"
       },
       "devDependencies": {
@@ -72,7 +71,6 @@
         "@types/passport-oauth2": "^1.8.0",
         "@types/superagent": "^8.1.10",
         "@types/supertest": "^7.2.0",
-        "@types/uuid": "^11.0.0",
         "audit-ci": "^7.1.0",
         "aws-sdk-client-mock": "^4.1.0",
         "axe-core": "^4.11.4",
@@ -6764,17 +6762,6 @@
       "resolved": "https://registry.npmjs.org/@types/tmp/-/tmp-0.2.6.tgz",
       "integrity": "sha512-chhaNf2oKHlRkDGt+tiKE2Z5aJ6qalm7Z9rlLdBwmOiAAf09YQvvoLXjWK4HWPF1xU/fqvMgfNfpVoBscA/tKA==",
       "license": "MIT"
-    },
-    "node_modules/@types/uuid": {
-      "version": "11.0.0",
-      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-11.0.0.tgz",
-      "integrity": "sha512-HVyk8nj2m+jcFRNazzqyVKiZezyhDKrGUA3jlEcg/nZ6Ms+qHwocba1Y/AaVaznJTAM9xpdFSh+ptbNrhOGvZA==",
-      "deprecated": "This is a stub types definition. uuid provides its own type definitions, so you do not need this installed.",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "uuid": "*"
-      }
     },
     "node_modules/@types/yargs": {
       "version": "17.0.35",
@@ -20563,19 +20550,6 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.4.0"
-      }
-    },
-    "node_modules/uuid": {
-      "version": "11.1.1",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.1.tgz",
-      "integrity": "sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ==",
-      "funding": [
-        "https://github.com/sponsors/broofa",
-        "https://github.com/sponsors/ctavan"
-      ],
-      "license": "MIT",
-      "bin": {
-        "uuid": "dist/esm/bin/uuid"
       }
     },
     "node_modules/v8-to-istanbul": {

--- a/package.json
+++ b/package.json
@@ -67,7 +67,6 @@
     "redis": "^5.12.1",
     "superagent": "^10.3.0",
     "url-value-parser": "^2.2.0",
-    "uuid": "^11.1.1",
     "zod": "^4.4.3"
   },
   "devDependencies": {
@@ -95,7 +94,6 @@
     "@types/passport-oauth2": "^1.8.0",
     "@types/superagent": "^8.1.10",
     "@types/supertest": "^7.2.0",
-    "@types/uuid": "^11.0.0",
     "audit-ci": "^7.1.0",
     "aws-sdk-client-mock": "^4.1.0",
     "axe-core": "^4.11.4",

--- a/server/errorHandler.test.ts
+++ b/server/errorHandler.test.ts
@@ -1,6 +1,6 @@
+import { randomUUID } from 'node:crypto'
 import type { Express } from 'express'
 import request from 'supertest'
-import { v4 as uuidV4 } from 'uuid'
 import { appWithAllRoutes } from './routes/testutils/appSetup'
 
 let app: Express
@@ -16,7 +16,7 @@ afterEach(() => {
 describe('GET 404', () => {
   it('should render content with stack in dev mode', () => {
     return request(app)
-      .get(`/${uuidV4()}/unknown`)
+      .get(`/${randomUUID()}/unknown`)
       .expect(404)
       .expect('Content-Type', /html/)
       .expect(res => {
@@ -27,7 +27,7 @@ describe('GET 404', () => {
 
   it('should render content without stack in production mode', () => {
     return request(appWithAllRoutes({ production: true }))
-      .get(`/${uuidV4()}/unknown`)
+      .get(`/${randomUUID()}/unknown`)
       .expect(404)
       .expect('Content-Type', /html/)
       .expect(res => {

--- a/server/middleware/auditPageViewMiddleware.ts
+++ b/server/middleware/auditPageViewMiddleware.ts
@@ -1,10 +1,10 @@
 import { RequestHandler } from 'express'
-import { validate } from 'uuid'
+import { validateUuid } from '../utils/validateUuid'
 import AuditService from '../services/auditService'
 
 export const auditPageViewMiddleware = (auditService: AuditService): RequestHandler => {
   return async (req, res, next) => {
-    const hasJourneyId = validate(req.originalUrl.split('/')[1])
+    const hasJourneyId = validateUuid(req.originalUrl.split('/')[1])
     let pageNameSuffix = req.originalUrl.replace(/\?.*/, '')
     const splitUrl = pageNameSuffix.toUpperCase().split('/')
     if (hasJourneyId) {

--- a/server/middleware/insertJourneyIdentifier.test.ts
+++ b/server/middleware/insertJourneyIdentifier.test.ts
@@ -1,0 +1,39 @@
+import { randomUUID } from 'node:crypto'
+import type { Request, Response } from 'express'
+import insertJourneyIdentifier from './insertJourneyIdentifier'
+
+describe('insertJourneyIdentifier', () => {
+  const uuid = randomUUID()
+
+  it.each([`/${uuid}`, `/${uuid}/update`, `/${uuid}/update/123`])(
+    'should call next when url has a journey identifier like %j',
+    url => {
+      const { res, next } = mockRequest(url)
+
+      expect(res.redirect).not.toHaveBeenCalled()
+      expect(next).toHaveBeenCalled()
+    },
+  )
+
+  it.each(['', '/', '/update', '/update/123', `/update/${uuid}`])(
+    'should redirect since url %j does not contain a journey identifier',
+    url => {
+      const { res, next } = mockRequest(url)
+
+      expect(res.redirect).toHaveBeenCalled()
+      const [redirectUrl] = jest.mocked(res.redirect).mock.calls[0] as unknown as [string]
+      expect(redirectUrl.startsWith('http://localhost/')).toBe(true)
+      expect(redirectUrl.endsWith(url)).toBe(true)
+      expect(next).not.toHaveBeenCalled()
+    },
+  )
+})
+
+function mockRequest(url: string) {
+  const req = { baseUrl: 'http://localhost', url } as unknown as Request
+  const res = { redirect: jest.fn() } as unknown as Response
+  const next = jest.fn()
+  const middleware = insertJourneyIdentifier()
+  middleware(req, res, next)
+  return { req, res, next }
+}

--- a/server/middleware/insertJourneyIdentifier.ts
+++ b/server/middleware/insertJourneyIdentifier.ts
@@ -1,13 +1,14 @@
 import { randomUUID } from 'node:crypto'
-import type { NextFunction, Request, Response } from 'express'
+import type { RequestHandler } from 'express'
 import { validateUuid } from '../utils/validateUuid'
 
-export default function insertJourneyIdentifier() {
-  return (req: Request, res: Response, next: NextFunction): void => {
+export default function insertJourneyIdentifier(): RequestHandler {
+  return (req, res, next): void => {
     const uuid = req.url.split('/')[1] || '/'
     if (!validateUuid(uuid)) {
-      return res.redirect(`${req.baseUrl}/${randomUUID()}${req.url}`)
+      res.redirect(`${req.baseUrl}/${randomUUID()}${req.url}`)
+      return
     }
-    return next()
+    next()
   }
 }

--- a/server/middleware/insertJourneyIdentifier.ts
+++ b/server/middleware/insertJourneyIdentifier.ts
@@ -1,11 +1,12 @@
+import { randomUUID } from 'node:crypto'
 import type { NextFunction, Request, Response } from 'express'
-import { v4 as uuidV4, validate } from 'uuid'
+import { validateUuid } from '../utils/validateUuid'
 
 export default function insertJourneyIdentifier() {
   return (req: Request, res: Response, next: NextFunction): void => {
     const uuid = req.url.split('/')[1] || '/'
-    if (!validate(uuid)) {
-      return res.redirect(`${req.baseUrl}/${uuidV4()}${req.url}`)
+    if (!validateUuid(uuid)) {
+      return res.redirect(`${req.baseUrl}/${randomUUID()}${req.url}`)
     }
     return next()
   }

--- a/server/middleware/setUpJourneyData.test.ts
+++ b/server/middleware/setUpJourneyData.test.ts
@@ -1,6 +1,6 @@
+import { randomUUID } from 'node:crypto'
 import { TokenStore } from '@ministryofjustice/hmpps-auth-clients'
 import { Request, RequestHandler, Response } from 'express'
-import { v4 as uuidV4 } from 'uuid'
 import setUpJourneyData from './setUpJourneyData'
 
 let middleware: RequestHandler
@@ -14,7 +14,7 @@ let journeyId: string
 const next = jest.fn()
 
 beforeEach(() => {
-  journeyId = uuidV4()
+  journeyId = randomUUID()
 
   res = {
     callback: () => null,

--- a/server/routes/journeys/bulk-alerts/cancellation-check/tests.cy.ts
+++ b/server/routes/journeys/bulk-alerts/cancellation-check/tests.cy.ts
@@ -1,9 +1,9 @@
-import { v4 as uuidV4 } from 'uuid'
+import { randomUUID } from 'node:crypto'
 import AuthorisedRoles from '../../../../utils/authorisedRoles'
 import injectJourneyDataAndReload from '../../../../../integration_tests/utils/e2eTestUtils'
 
 context('test /bulk-alerts/cancellation-check', () => {
-  const uuid = uuidV4()
+  const uuid = randomUUID()
 
   beforeEach(() => {
     cy.task('reset')

--- a/server/routes/journeys/bulk-alerts/check-answers/tests.cy.ts
+++ b/server/routes/journeys/bulk-alerts/check-answers/tests.cy.ts
@@ -1,9 +1,9 @@
-import { v4 as uuidV4 } from 'uuid'
+import { randomUUID } from 'node:crypto'
 import AuthorisedRoles from '../../../../utils/authorisedRoles'
 import injectJourneyDataAndReload from '../../../../../integration_tests/utils/e2eTestUtils'
 
 context('test /bulk-alerts/check-answers', () => {
-  const uuid = uuidV4()
+  const uuid = randomUUID()
 
   beforeEach(() => {
     cy.task('reset')

--- a/server/routes/journeys/bulk-alerts/confirmation/tests.cy.ts
+++ b/server/routes/journeys/bulk-alerts/confirmation/tests.cy.ts
@@ -1,9 +1,9 @@
-import { v4 as uuidV4 } from 'uuid'
+import { randomUUID } from 'node:crypto'
 import AuthorisedRoles from '../../../../utils/authorisedRoles'
 import injectJourneyDataAndReload from '../../../../../integration_tests/utils/e2eTestUtils'
 
 context('test /bulk-alerts/confirmation', () => {
-  const uuid = uuidV4()
+  const uuid = randomUUID()
 
   beforeEach(() => {
     cy.task('reset')

--- a/server/routes/journeys/bulk-alerts/enter-alert-reason/tests.cy.ts
+++ b/server/routes/journeys/bulk-alerts/enter-alert-reason/tests.cy.ts
@@ -1,8 +1,8 @@
-import { v4 as uuidV4 } from 'uuid'
+import { randomUUID } from 'node:crypto'
 import AuthorisedRoles from '../../../../utils/authorisedRoles'
 
 context('test /bulk-alerts/enter-alert-reason screen', () => {
-  const uuid = uuidV4()
+  const uuid = randomUUID()
 
   const getContinueButton = () => cy.findByRole('button', { name: /Continue/ })
   const getDescriptionInput = () => cy.findByRole('textbox', { name: /Enter why you are creating this alert$/ })

--- a/server/routes/journeys/bulk-alerts/how-to-add-prisoners/tests.cy.ts
+++ b/server/routes/journeys/bulk-alerts/how-to-add-prisoners/tests.cy.ts
@@ -1,9 +1,9 @@
-import { v4 as uuidV4 } from 'uuid'
+import { randomUUID } from 'node:crypto'
 import AuthorisedRoles from '../../../../utils/authorisedRoles'
 import injectJourneyDataAndReload from '../../../../../integration_tests/utils/e2eTestUtils'
 
 context('test /bulk-alerts/how-to-add-prisoners screen', () => {
-  const uuid = uuidV4()
+  const uuid = randomUUID()
 
   const getContinueButton = () => cy.findByRole('button', { name: /Continue/ })
   const getRadio1 = () => cy.findByRole('radio', { name: /Search for them one by one/ })

--- a/server/routes/journeys/bulk-alerts/review-prisoners/tests.cy.ts
+++ b/server/routes/journeys/bulk-alerts/review-prisoners/tests.cy.ts
@@ -1,9 +1,9 @@
-import { v4 as uuidV4 } from 'uuid'
+import { randomUUID } from 'node:crypto'
 import AuthorisedRoles from '../../../../utils/authorisedRoles'
 import injectJourneyDataAndReload from '../../../../../integration_tests/utils/e2eTestUtils'
 
 context('test /bulk-alerts/review-prisoners screen', () => {
-  const uuid = uuidV4()
+  const uuid = randomUUID()
 
   beforeEach(() => {
     cy.task('reset')

--- a/server/routes/journeys/bulk-alerts/select-prisoner/tests.cy.ts
+++ b/server/routes/journeys/bulk-alerts/select-prisoner/tests.cy.ts
@@ -1,9 +1,9 @@
-import { v4 as uuidV4 } from 'uuid'
+import { randomUUID } from 'node:crypto'
 import AuthorisedRoles from '../../../../utils/authorisedRoles'
 import injectJourneyDataAndReload from '../../../../../integration_tests/utils/e2eTestUtils'
 
 context('test /bulk-alerts/select-prisoner screen', () => {
-  const uuid = uuidV4()
+  const uuid = randomUUID()
 
   const getQueryInput = () => cy.findByRole('textbox', { name: /Who should have the ‘OCG Nominal’ alert applied\?/ })
   const getSearchButton = () => cy.findByRole('button', { name: /^Search$/ })

--- a/server/routes/journeys/bulk-alerts/select-upload-logic/tests.cy.ts
+++ b/server/routes/journeys/bulk-alerts/select-upload-logic/tests.cy.ts
@@ -1,9 +1,9 @@
-import { v4 as uuidV4 } from 'uuid'
+import { randomUUID } from 'node:crypto'
 import AuthorisedRoles from '../../../../utils/authorisedRoles'
 import injectJourneyDataAndReload from '../../../../../integration_tests/utils/e2eTestUtils'
 
 context('test /bulk-alerts/select-upload-logic screen', () => {
-  const uuid = uuidV4()
+  const uuid = randomUUID()
 
   const getContinueButton = () => cy.findByRole('button', { name: /Continue/ })
   const getRadio1 = () =>

--- a/server/routes/journeys/bulk-alerts/upload-prisoner-list/tests.cy.ts
+++ b/server/routes/journeys/bulk-alerts/upload-prisoner-list/tests.cy.ts
@@ -1,9 +1,9 @@
-import { v4 as uuidV4 } from 'uuid'
+import { randomUUID } from 'node:crypto'
 import AuthorisedRoles from '../../../../utils/authorisedRoles'
 import injectJourneyDataAndReload from '../../../../../integration_tests/utils/e2eTestUtils'
 
 context('test /bulk-alerts/upload-prisoner-list screen', () => {
-  const uuid = uuidV4()
+  const uuid = randomUUID()
 
   const getChooseFile = () => cy.get('input[type="file"]')
   const getUploadButton = () => cy.findByRole('button', { name: /^Upload file$/ })

--- a/server/routes/journeys/manage-alert-restrictions/check-answers/tests.cy.ts
+++ b/server/routes/journeys/manage-alert-restrictions/check-answers/tests.cy.ts
@@ -1,10 +1,10 @@
-import { v4 as uuidV4 } from 'uuid'
+import { randomUUID } from 'node:crypto'
 import AuthorisedRoles from '../../../../utils/authorisedRoles'
 import injectJourneyDataAndReload from '../../../../../integration_tests/utils/e2eTestUtils'
 import { ManageAlertRestrictionsJourney } from '../../../../@types/express'
 
 context('test /manage-alert-restrictions/check-answers', () => {
-  let uuid = uuidV4()
+  let uuid = randomUUID()
 
   const defaultJourneyData: ManageAlertRestrictionsJourney = {
     alertType: {
@@ -40,7 +40,7 @@ context('test /manage-alert-restrictions/check-answers', () => {
   })
 
   it('should check answers for Restrict Alert', () => {
-    uuid = uuidV4()
+    uuid = randomUUID()
     navigateToTestPage({
       ...defaultJourneyData,
       changeType: 'RESTRICT_ALERT',
@@ -68,7 +68,7 @@ context('test /manage-alert-restrictions/check-answers', () => {
   })
 
   it('should check answers for Remove Alert Restriction', () => {
-    uuid = uuidV4()
+    uuid = randomUUID()
     navigateToTestPage({
       ...defaultJourneyData,
       changeType: 'REMOVE_ALERT_RESTRICTION',
@@ -96,7 +96,7 @@ context('test /manage-alert-restrictions/check-answers', () => {
   })
 
   it('should check answers for Add Privileged User', () => {
-    uuid = uuidV4()
+    uuid = randomUUID()
     navigateToTestPage({
       ...defaultJourneyData,
       changeType: 'ADD_PRIVILEGED_USER',
@@ -133,7 +133,7 @@ context('test /manage-alert-restrictions/check-answers', () => {
   })
 
   it('should check answers for Remove Privileged User', () => {
-    uuid = uuidV4()
+    uuid = randomUUID()
     navigateToTestPage({
       ...defaultJourneyData,
       changeType: 'REMOVE_PRIVILEGED_USER',

--- a/server/routes/journeys/manage-alert-restrictions/confirmation/tests.cy.ts
+++ b/server/routes/journeys/manage-alert-restrictions/confirmation/tests.cy.ts
@@ -1,10 +1,10 @@
-import { v4 as uuidV4 } from 'uuid'
+import { randomUUID } from 'node:crypto'
 import AuthorisedRoles from '../../../../utils/authorisedRoles'
 import injectJourneyDataAndReload from '../../../../../integration_tests/utils/e2eTestUtils'
 import { ManageAlertRestrictionsJourney } from '../../../../@types/express'
 
 context('test /manage-alert-restrictions/confirmation', () => {
-  let uuid = uuidV4()
+  let uuid = randomUUID()
 
   const defaultJourneyData: ManageAlertRestrictionsJourney = {
     alertType: {
@@ -36,7 +36,7 @@ context('test /manage-alert-restrictions/confirmation', () => {
   })
 
   it('should show RESTRICT_ALERT confirmation page', () => {
-    uuid = uuidV4()
+    uuid = randomUUID()
     navigateToTestPage({
       ...defaultJourneyData,
       changeType: 'RESTRICT_ALERT',
@@ -51,7 +51,7 @@ context('test /manage-alert-restrictions/confirmation', () => {
   })
 
   it('should show REMOVE_ALERT_RESTRICTION confirmation page', () => {
-    uuid = uuidV4()
+    uuid = randomUUID()
     navigateToTestPage({
       ...defaultJourneyData,
       changeType: 'REMOVE_ALERT_RESTRICTION',
@@ -66,7 +66,7 @@ context('test /manage-alert-restrictions/confirmation', () => {
   })
 
   it('should show ADD_PRIVILEGED_USER confirmation page', () => {
-    uuid = uuidV4()
+    uuid = randomUUID()
     navigateToTestPage({
       ...defaultJourneyData,
       changeType: 'ADD_PRIVILEGED_USER',
@@ -84,7 +84,7 @@ context('test /manage-alert-restrictions/confirmation', () => {
   })
 
   it('should show REMOVE_PRIVILEGED_USER confirmation page', () => {
-    uuid = uuidV4()
+    uuid = randomUUID()
     navigateToTestPage({
       ...defaultJourneyData,
       changeType: 'REMOVE_PRIVILEGED_USER',

--- a/server/routes/journeys/manage-alert-restrictions/select-alert-code/tests.cy.ts
+++ b/server/routes/journeys/manage-alert-restrictions/select-alert-code/tests.cy.ts
@@ -1,9 +1,9 @@
-import { v4 as uuidV4 } from 'uuid'
+import { randomUUID } from 'node:crypto'
 import AuthorisedRoles from '../../../../utils/authorisedRoles'
 import injectJourneyDataAndReload from '../../../../../integration_tests/utils/e2eTestUtils'
 
 context('test /manage-alert-restrictions/select-alert-code screen', () => {
-  let uuid = uuidV4()
+  let uuid = randomUUID()
 
   const getContinueButton = () => cy.findByRole('button', { name: /Continue/ })
   const getAlertCodeRadio1 = () => cy.findByRole('radio', { name: /AA \(AA description\)$/ })
@@ -30,7 +30,7 @@ context('test /manage-alert-restrictions/select-alert-code screen', () => {
   })
 
   it('should try out RESTRICT_ALERT cases', () => {
-    uuid = uuidV4()
+    uuid = randomUUID()
     navigateToTestPage('RESTRICT_ALERT')
     cy.url().should('to.match', /\/manage-alert-restrictions\/select-alert-code$/)
     cy.checkAxeAccessibility()
@@ -55,7 +55,7 @@ context('test /manage-alert-restrictions/select-alert-code screen', () => {
   })
 
   it('should try out REMOVE_ALERT_RESTRICTION cases', () => {
-    uuid = uuidV4()
+    uuid = randomUUID()
     navigateToTestPage('REMOVE_ALERT_RESTRICTION')
     cy.url().should('to.match', /\/manage-alert-restrictions\/select-alert-code$/)
     cy.checkAxeAccessibility()
@@ -74,7 +74,7 @@ context('test /manage-alert-restrictions/select-alert-code screen', () => {
   })
 
   it('should try out ADD_PRIVILEGED_USER cases', () => {
-    uuid = uuidV4()
+    uuid = randomUUID()
     navigateToTestPage('ADD_PRIVILEGED_USER')
     cy.url().should('to.match', /\/manage-alert-restrictions\/select-alert-code$/)
     cy.checkAxeAccessibility()
@@ -93,7 +93,7 @@ context('test /manage-alert-restrictions/select-alert-code screen', () => {
   })
 
   it('should try out REMOVE_PRIVILEGED_USER cases', () => {
-    uuid = uuidV4()
+    uuid = randomUUID()
     navigateToTestPage('REMOVE_PRIVILEGED_USER')
     cy.url().should('to.match', /\/manage-alert-restrictions\/select-alert-code$/)
     cy.checkAxeAccessibility()

--- a/server/routes/journeys/manage-alert-restrictions/select-alert-type/tests.cy.ts
+++ b/server/routes/journeys/manage-alert-restrictions/select-alert-type/tests.cy.ts
@@ -1,9 +1,9 @@
-import { v4 as uuidV4 } from 'uuid'
+import { randomUUID } from 'node:crypto'
 import AuthorisedRoles from '../../../../utils/authorisedRoles'
 import injectJourneyDataAndReload from '../../../../../integration_tests/utils/e2eTestUtils'
 
 context('test /manage-alert-restrictions/select-alert-type screen', () => {
-  let uuid = uuidV4()
+  let uuid = randomUUID()
 
   const getContinueButton = () => cy.findByRole('button', { name: /Continue/ })
   const getAlertTypeRadio1 = () => cy.findByRole('radio', { name: /AA \(A description\)$/ })
@@ -53,7 +53,7 @@ context('test /manage-alert-restrictions/select-alert-type screen', () => {
   })
 
   it('should try out REMOVE_ALERT_RESTRICTION cases', () => {
-    uuid = uuidV4()
+    uuid = randomUUID()
     navigateToTestPage('REMOVE_ALERT_RESTRICTION')
     cy.url().should('to.match', /\/manage-alert-restrictions\/select-alert-type$/)
     cy.checkAxeAccessibility()
@@ -70,7 +70,7 @@ context('test /manage-alert-restrictions/select-alert-type screen', () => {
   })
 
   it('should try out ADD_PRIVILEGED_USER cases', () => {
-    uuid = uuidV4()
+    uuid = randomUUID()
     navigateToTestPage('ADD_PRIVILEGED_USER')
     cy.url().should('to.match', /\/manage-alert-restrictions\/select-alert-type$/)
     cy.checkAxeAccessibility()
@@ -87,7 +87,7 @@ context('test /manage-alert-restrictions/select-alert-type screen', () => {
   })
 
   it('should try out REMOVE_PRIVILEGED_USER cases', () => {
-    uuid = uuidV4()
+    uuid = randomUUID()
     navigateToTestPage('REMOVE_PRIVILEGED_USER')
     cy.url().should('to.match', /\/manage-alert-restrictions\/select-alert-type$/)
     cy.checkAxeAccessibility()

--- a/server/routes/journeys/manage-alert-restrictions/select-user/tests.cy.ts
+++ b/server/routes/journeys/manage-alert-restrictions/select-user/tests.cy.ts
@@ -1,9 +1,9 @@
-import { v4 as uuidV4 } from 'uuid'
+import { randomUUID } from 'node:crypto'
 import AuthorisedRoles from '../../../../utils/authorisedRoles'
 import injectJourneyDataAndReload from '../../../../../integration_tests/utils/e2eTestUtils'
 
 context('test /manage-alert-restrictions/select-user screen', () => {
-  const uuid = uuidV4()
+  const uuid = randomUUID()
 
   const getContinueButton = () => cy.findByRole('button', { name: /Continue/ })
   const getUsernameInput = () => cy.findByRole('textbox', { name: /Enter a username$/ })

--- a/server/routes/journeys/manage-alert-restrictions/tests.cy.ts
+++ b/server/routes/journeys/manage-alert-restrictions/tests.cy.ts
@@ -1,9 +1,9 @@
-import { v4 as uuidV4 } from 'uuid'
+import { randomUUID } from 'node:crypto'
 import AuthorisedRoles from '../../../utils/authorisedRoles'
 import Chainable = Cypress.Chainable
 
 context('Manage alert restrictions page', () => {
-  const uuid = uuidV4()
+  const uuid = randomUUID()
 
   const getRestrictAlertRadio = () => cy.findByRole('radio', { name: /Restrict alert$/ })
   const getRemoveRestrictionRadio = () => cy.findByRole('radio', { name: /Remove alert restriction$/ })

--- a/server/routes/journeys/update-reference-data/add-alert-code/tests.cy.ts
+++ b/server/routes/journeys/update-reference-data/add-alert-code/tests.cy.ts
@@ -1,9 +1,9 @@
-import { v4 as uuidV4 } from 'uuid'
+import { randomUUID } from 'node:crypto'
 import AuthorisedRoles from '../../../../utils/authorisedRoles'
 import injectJourneyDataAndReload from '../../../../../integration_tests/utils/e2eTestUtils'
 
 context('test /update-reference-data/add-alert-code screen', () => {
-  const uuid = uuidV4()
+  const uuid = randomUUID()
 
   const getContinueButton = () => cy.findByRole('button', { name: /Continue/ })
   const getCodeInput = () => cy.findByRole('textbox', { name: /Enter an alert code$/ })

--- a/server/routes/journeys/update-reference-data/add-alert-type/tests.cy.ts
+++ b/server/routes/journeys/update-reference-data/add-alert-type/tests.cy.ts
@@ -1,9 +1,9 @@
-import { v4 as uuidV4 } from 'uuid'
+import { randomUUID } from 'node:crypto'
 import AuthorisedRoles from '../../../../utils/authorisedRoles'
 import injectJourneyDataAndReload from '../../../../../integration_tests/utils/e2eTestUtils'
 
 context('test /update-reference-data/add-alert-type screen', () => {
-  const uuid = uuidV4()
+  const uuid = randomUUID()
 
   const getContinueButton = () => cy.findByRole('button', { name: /Continue/ })
   const getCodeInput = () => cy.findByRole('textbox', { name: /Enter an alert type code$/ })

--- a/server/routes/journeys/update-reference-data/check-answers/tests.cy.ts
+++ b/server/routes/journeys/update-reference-data/check-answers/tests.cy.ts
@@ -1,10 +1,10 @@
-import { v4 as uuidV4 } from 'uuid'
+import { randomUUID } from 'node:crypto'
 import AuthorisedRoles from '../../../../utils/authorisedRoles'
 import injectJourneyDataAndReload from '../../../../../integration_tests/utils/e2eTestUtils'
 import { UpdateReferenceDataJourney } from '../../../../@types/express'
 
 context('test /update-reference-data/check-answers', () => {
-  let uuid = uuidV4()
+  let uuid = randomUUID()
 
   beforeEach(() => {
     cy.task('reset')
@@ -20,7 +20,7 @@ context('test /update-reference-data/check-answers', () => {
   })
 
   it('should check answers for Create Alert Type', () => {
-    uuid = uuidV4()
+    uuid = randomUUID()
     navigateToTestPage({
       referenceDataType: 'ALERT_TYPE',
       changeType: 'ADD_NEW',
@@ -50,7 +50,7 @@ context('test /update-reference-data/check-answers', () => {
   })
 
   it('should check answers for Edit Alert Type', () => {
-    uuid = uuidV4()
+    uuid = randomUUID()
     navigateToTestPage({
       referenceDataType: 'ALERT_TYPE',
       changeType: 'EDIT_DESCRIPTION',
@@ -87,7 +87,7 @@ context('test /update-reference-data/check-answers', () => {
   })
 
   it('should check answers for Reactivate Alert Type', () => {
-    uuid = uuidV4()
+    uuid = randomUUID()
     navigateToTestPage({
       referenceDataType: 'ALERT_TYPE',
       changeType: 'REACTIVATE',
@@ -117,7 +117,7 @@ context('test /update-reference-data/check-answers', () => {
   })
 
   it('should check answers for Create Alert Code', () => {
-    uuid = uuidV4()
+    uuid = randomUUID()
     navigateToTestPage({
       referenceDataType: 'ALERT_CODE',
       changeType: 'ADD_NEW',
@@ -161,7 +161,7 @@ context('test /update-reference-data/check-answers', () => {
   })
 
   it('should check answers for Edit Alert Code', () => {
-    uuid = uuidV4()
+    uuid = randomUUID()
     navigateToTestPage({
       referenceDataType: 'ALERT_CODE',
       changeType: 'EDIT_DESCRIPTION',
@@ -216,7 +216,7 @@ context('test /update-reference-data/check-answers', () => {
   })
 
   it('should check answers for Reactivate Alert Code', () => {
-    uuid = uuidV4()
+    uuid = randomUUID()
     navigateToTestPage({
       referenceDataType: 'ALERT_CODE',
       changeType: 'REACTIVATE',

--- a/server/routes/journeys/update-reference-data/confirmation/tests.cy.ts
+++ b/server/routes/journeys/update-reference-data/confirmation/tests.cy.ts
@@ -1,10 +1,10 @@
-import { v4 as uuidV4 } from 'uuid'
+import { randomUUID } from 'node:crypto'
 import AuthorisedRoles from '../../../../utils/authorisedRoles'
 import injectJourneyDataAndReload from '../../../../../integration_tests/utils/e2eTestUtils'
 import { UpdateReferenceDataJourney } from '../../../../@types/express'
 
 context('test /update-reference-data/confirmation', () => {
-  let uuid = uuidV4()
+  let uuid = randomUUID()
 
   beforeEach(() => {
     cy.task('reset')
@@ -14,7 +14,7 @@ context('test /update-reference-data/confirmation', () => {
   })
 
   it('should show ADD_NEW ALERT_TYPE confirmation page', () => {
-    uuid = uuidV4()
+    uuid = randomUUID()
     navigateToTestPage({
       referenceDataType: 'ALERT_TYPE',
       changeType: 'ADD_NEW',
@@ -31,7 +31,7 @@ context('test /update-reference-data/confirmation', () => {
   })
 
   it('should show EDIT_DESCRIPTION ALERT_TYPE confirmation page', () => {
-    uuid = uuidV4()
+    uuid = randomUUID()
     navigateToTestPage({
       referenceDataType: 'ALERT_TYPE',
       changeType: 'EDIT_DESCRIPTION',
@@ -55,7 +55,7 @@ context('test /update-reference-data/confirmation', () => {
   })
 
   it('should show DEACTIVATE ALERT_TYPE confirmation page', () => {
-    uuid = uuidV4()
+    uuid = randomUUID()
     navigateToTestPage({
       referenceDataType: 'ALERT_TYPE',
       changeType: 'DEACTIVATE',
@@ -78,7 +78,7 @@ context('test /update-reference-data/confirmation', () => {
   })
 
   it('should show REACTIVATE ALERT_TYPE confirmation page', () => {
-    uuid = uuidV4()
+    uuid = randomUUID()
     navigateToTestPage({
       referenceDataType: 'ALERT_TYPE',
       changeType: 'REACTIVATE',
@@ -101,7 +101,7 @@ context('test /update-reference-data/confirmation', () => {
   })
 
   it('should show ADD_NEW ALERT_CODE confirmation page', () => {
-    uuid = uuidV4()
+    uuid = randomUUID()
     navigateToTestPage({
       referenceDataType: 'ALERT_CODE',
       changeType: 'ADD_NEW',
@@ -118,7 +118,7 @@ context('test /update-reference-data/confirmation', () => {
   })
 
   it('should show EDIT_DESCRIPTION ALERT_CODE confirmation page', () => {
-    uuid = uuidV4()
+    uuid = randomUUID()
     navigateToTestPage({
       referenceDataType: 'ALERT_CODE',
       changeType: 'EDIT_DESCRIPTION',
@@ -144,7 +144,7 @@ context('test /update-reference-data/confirmation', () => {
   })
 
   it('should show DEACTIVATE ALERT_CODE confirmation page', () => {
-    uuid = uuidV4()
+    uuid = randomUUID()
     navigateToTestPage({
       referenceDataType: 'ALERT_CODE',
       changeType: 'DEACTIVATE',
@@ -169,7 +169,7 @@ context('test /update-reference-data/confirmation', () => {
   })
 
   it('should show REACTIVATE ALERT_CODE confirmation page', () => {
-    uuid = uuidV4()
+    uuid = randomUUID()
     navigateToTestPage({
       referenceDataType: 'ALERT_CODE',
       changeType: 'REACTIVATE',

--- a/server/routes/journeys/update-reference-data/deactivate-alert-code/tests.cy.ts
+++ b/server/routes/journeys/update-reference-data/deactivate-alert-code/tests.cy.ts
@@ -1,4 +1,4 @@
-import { v4 as uuidV4 } from 'uuid'
+import { randomUUID } from 'node:crypto'
 import AuthorisedRoles from '../../../../utils/authorisedRoles'
 import injectJourneyDataAndReload from '../../../../../integration_tests/utils/e2eTestUtils'
 
@@ -7,7 +7,7 @@ context('test /update-reference-data/deactivate-alert-code', () => {
   const getYesRadio = () => cy.findByRole('radio', { name: /Yes$/ })
   const getNoRadio = () => cy.findByRole('radio', { name: /No$/ })
 
-  let uuid = uuidV4()
+  let uuid = randomUUID()
 
   beforeEach(() => {
     cy.task('reset')
@@ -18,7 +18,7 @@ context('test /update-reference-data/deactivate-alert-code', () => {
   })
 
   it('should confirm to deactivate Alert Code', () => {
-    uuid = uuidV4()
+    uuid = randomUUID()
     navigateToTestPage()
     cy.url().should('to.match', /\/deactivate-alert-code$/)
     cy.checkAxeAccessibility()
@@ -45,7 +45,7 @@ context('test /update-reference-data/deactivate-alert-code', () => {
   })
 
   it('should cancel deactivating Alert Code and return to homepage', () => {
-    uuid = uuidV4()
+    uuid = randomUUID()
     navigateToTestPage()
     cy.url().should('to.match', /\/deactivate-alert-code$/)
 

--- a/server/routes/journeys/update-reference-data/deactivate-alert-type/tests.cy.ts
+++ b/server/routes/journeys/update-reference-data/deactivate-alert-type/tests.cy.ts
@@ -1,4 +1,4 @@
-import { v4 as uuidV4 } from 'uuid'
+import { randomUUID } from 'node:crypto'
 import AuthorisedRoles from '../../../../utils/authorisedRoles'
 import injectJourneyDataAndReload from '../../../../../integration_tests/utils/e2eTestUtils'
 
@@ -7,7 +7,7 @@ context('test /update-reference-data/deactivate-alert-type', () => {
   const getYesRadio = () => cy.findByRole('radio', { name: /Yes$/ })
   const getNoRadio = () => cy.findByRole('radio', { name: /No$/ })
 
-  let uuid = uuidV4()
+  let uuid = randomUUID()
 
   beforeEach(() => {
     cy.task('reset')
@@ -18,7 +18,7 @@ context('test /update-reference-data/deactivate-alert-type', () => {
   })
 
   it('should confirm to deactivate Alert Type', () => {
-    uuid = uuidV4()
+    uuid = randomUUID()
     navigateToTestPage()
     cy.url().should('to.match', /\/deactivate-alert-type$/)
     cy.checkAxeAccessibility()
@@ -48,7 +48,7 @@ context('test /update-reference-data/deactivate-alert-type', () => {
   })
 
   it('should cancel deactivating Alert Type and return to homepage', () => {
-    uuid = uuidV4()
+    uuid = randomUUID()
     navigateToTestPage()
     cy.url().should('to.match', /\/deactivate-alert-type$/)
 

--- a/server/routes/journeys/update-reference-data/edit-alert-code/tests.cy.ts
+++ b/server/routes/journeys/update-reference-data/edit-alert-code/tests.cy.ts
@@ -1,10 +1,10 @@
-import { v4 as uuidV4 } from 'uuid'
+import { randomUUID } from 'node:crypto'
 import AuthorisedRoles from '../../../../utils/authorisedRoles'
 
 import injectJourneyDataAndReload from '../../../../../integration_tests/utils/e2eTestUtils'
 
 context('test /update-reference-data/add-alert-code screen', () => {
-  const uuid = uuidV4()
+  const uuid = randomUUID()
 
   const getContinueButton = () => cy.findByRole('button', { name: /Continue/ })
   const getDescriptionInput = () => cy.findByRole('textbox', { name: /Enter a new alert description$/ })

--- a/server/routes/journeys/update-reference-data/edit-alert-type/tests.cy.ts
+++ b/server/routes/journeys/update-reference-data/edit-alert-type/tests.cy.ts
@@ -1,9 +1,9 @@
-import { v4 as uuidV4 } from 'uuid'
+import { randomUUID } from 'node:crypto'
 import AuthorisedRoles from '../../../../utils/authorisedRoles'
 import injectJourneyDataAndReload from '../../../../../integration_tests/utils/e2eTestUtils'
 
 context('test /update-reference-data/add-alert-type screen', () => {
-  const uuid = uuidV4()
+  const uuid = randomUUID()
 
   const getContinueButton = () => cy.findByRole('button', { name: /Continue/ })
   const getDescriptionInput = () => cy.findByRole('textbox', { name: /Enter a new alert type description$/ })

--- a/server/routes/journeys/update-reference-data/select-alert-code/tests.cy.ts
+++ b/server/routes/journeys/update-reference-data/select-alert-code/tests.cy.ts
@@ -1,10 +1,10 @@
-import { v4 as uuidV4 } from 'uuid'
+import { randomUUID } from 'node:crypto'
 import AuthorisedRoles from '../../../../utils/authorisedRoles'
 import injectJourneyDataAndReload from '../../../../../integration_tests/utils/e2eTestUtils'
 import { AlertType } from '../../../../@types/alerts/alertsApiTypes'
 
 context('test /update-reference-data/select-alert-code screen', () => {
-  let uuid = uuidV4()
+  let uuid = randomUUID()
 
   const getContinueButton = () => cy.findByRole('button', { name: /Continue/ })
   const getAlertCodeRadio1 = () => cy.findByRole('radio', { name: /AA \(AA description\)$/ })
@@ -21,7 +21,7 @@ context('test /update-reference-data/select-alert-code screen', () => {
   })
 
   it('should try out ALERT_CODE EDIT_DESCRIPTION cases', () => {
-    uuid = uuidV4()
+    uuid = randomUUID()
     navigateToTestPage('EDIT_DESCRIPTION')
     cy.url().should('to.match', /\/update-reference-data\/select-alert-code$/)
     cy.checkAxeAccessibility()
@@ -42,7 +42,7 @@ context('test /update-reference-data/select-alert-code screen', () => {
   })
 
   it('should try out ALERT_CODE DEACTIVATE cases', () => {
-    uuid = uuidV4()
+    uuid = randomUUID()
     navigateToTestPage('DEACTIVATE')
     cy.url().should('to.match', /\/update-reference-data\/select-alert-code$/)
     cy.checkAxeAccessibility()
@@ -57,7 +57,7 @@ context('test /update-reference-data/select-alert-code screen', () => {
   })
 
   it('should try out ALERT_CODE REACTIVATE cases', () => {
-    uuid = uuidV4()
+    uuid = randomUUID()
     navigateToTestPage('REACTIVATE')
     cy.url().should('to.match', /\/update-reference-data\/select-alert-code$/)
     cy.checkAxeAccessibility()

--- a/server/routes/journeys/update-reference-data/select-alert-type/tests.cy.ts
+++ b/server/routes/journeys/update-reference-data/select-alert-type/tests.cy.ts
@@ -1,9 +1,9 @@
-import { v4 as uuidV4 } from 'uuid'
+import { randomUUID } from 'node:crypto'
 import AuthorisedRoles from '../../../../utils/authorisedRoles'
 import injectJourneyDataAndReload from '../../../../../integration_tests/utils/e2eTestUtils'
 
 context('test /update-reference-data/select-alert-type screen', () => {
-  let uuid = uuidV4()
+  let uuid = randomUUID()
 
   const getContinueButton = () => cy.findByRole('button', { name: /Continue/ })
   const getAlertTypeRadio1 = () => cy.findByRole('radio', { name: /AA \(A description\)$/ })
@@ -43,7 +43,7 @@ context('test /update-reference-data/select-alert-type screen', () => {
   })
 
   it('should try out ALERT_TYPE DEACTIVATE cases', () => {
-    uuid = uuidV4()
+    uuid = randomUUID()
     navigateToTestPage('ALERT_TYPE', 'DEACTIVATE')
     cy.url().should('to.match', /\/update-reference-data\/select-alert-type$/)
     cy.checkAxeAccessibility()
@@ -59,7 +59,7 @@ context('test /update-reference-data/select-alert-type screen', () => {
   })
 
   it('should try out ALERT_TYPE REACTIVATE cases', () => {
-    uuid = uuidV4()
+    uuid = randomUUID()
     navigateToTestPage('ALERT_TYPE', 'REACTIVATE')
     cy.url().should('to.match', /\/update-reference-data\/select-alert-type$/)
     cy.checkAxeAccessibility()
@@ -75,7 +75,7 @@ context('test /update-reference-data/select-alert-type screen', () => {
   })
 
   it('should try out ALERT_CODE ADD_NEW cases', () => {
-    uuid = uuidV4()
+    uuid = randomUUID()
     navigateToTestPage('ALERT_CODE', 'ADD_NEW')
     cy.url().should('to.match', /\/update-reference-data\/select-alert-type$/)
     cy.checkAxeAccessibility()
@@ -91,7 +91,7 @@ context('test /update-reference-data/select-alert-type screen', () => {
   })
 
   it('should try out ALERT_CODE EDIT_DESCRIPTION cases', () => {
-    uuid = uuidV4()
+    uuid = randomUUID()
     navigateToTestPage('ALERT_CODE', 'EDIT_DESCRIPTION')
     cy.url().should('to.match', /\/update-reference-data\/select-alert-type$/)
     cy.checkAxeAccessibility()
@@ -107,7 +107,7 @@ context('test /update-reference-data/select-alert-type screen', () => {
   })
 
   it('should try out ALERT_CODE DEACTIVATE cases', () => {
-    uuid = uuidV4()
+    uuid = randomUUID()
     navigateToTestPage('ALERT_CODE', 'DEACTIVATE')
     cy.url().should('to.match', /\/update-reference-data\/select-alert-type$/)
     cy.checkAxeAccessibility()
@@ -123,7 +123,7 @@ context('test /update-reference-data/select-alert-type screen', () => {
   })
 
   it('should try out ALERT_CODE REACTIVATE cases', () => {
-    uuid = uuidV4()
+    uuid = randomUUID()
     navigateToTestPage('ALERT_CODE', 'REACTIVATE')
     cy.url().should('to.match', /\/update-reference-data\/select-alert-type$/)
     cy.checkAxeAccessibility()

--- a/server/routes/journeys/update-reference-data/select-change/tests.cy.ts
+++ b/server/routes/journeys/update-reference-data/select-change/tests.cy.ts
@@ -1,9 +1,9 @@
-import { v4 as uuidV4 } from 'uuid'
+import { randomUUID } from 'node:crypto'
 import AuthorisedRoles from '../../../../utils/authorisedRoles'
 import injectJourneyDataAndReload from '../../../../../integration_tests/utils/e2eTestUtils'
 
 context('test /update-reference-data/select-change screen', () => {
-  let uuid = uuidV4()
+  let uuid = randomUUID()
 
   const getContinueButton = () => cy.findByRole('button', { name: /Continue/ })
   const getAlertTypeRadio1 = () => cy.findByRole('radio', { name: /Add new alert type$/ })
@@ -49,7 +49,7 @@ context('test /update-reference-data/select-change screen', () => {
   })
 
   it('should try out ALERT_CODE cases', () => {
-    uuid = uuidV4()
+    uuid = randomUUID()
     navigateToTestPage('ALERT_CODE')
     cy.url().should('to.match', /\/update-reference-data\/select-change$/)
     cy.checkAxeAccessibility()

--- a/server/routes/journeys/update-reference-data/tests.cy.ts
+++ b/server/routes/journeys/update-reference-data/tests.cy.ts
@@ -1,8 +1,8 @@
-import { v4 as uuidV4 } from 'uuid'
+import { randomUUID } from 'node:crypto'
 import AuthorisedRoles from '../../../utils/authorisedRoles'
 
 context('test /update-reference-data screen', () => {
-  const uuid = uuidV4()
+  const uuid = randomUUID()
 
   const getContinueButton = () => cy.findByRole('button', { name: /Continue/ })
   const getRadio1 = () => cy.findByRole('radio', { name: /Alert$/ })

--- a/server/routes/testutils/appSetup.ts
+++ b/server/routes/testutils/appSetup.ts
@@ -1,9 +1,9 @@
+import { randomUUID } from 'node:crypto'
+import flash from 'connect-flash'
 import express, { Express } from 'express'
 import { NotFound } from 'http-errors'
 
 import { getFrontendComponents } from '@ministryofjustice/hmpps-connect-dps-components'
-import flash from 'connect-flash'
-import { randomUUID } from 'crypto'
 import routes from '../index'
 import nunjucksSetup from '../../utils/nunjucksSetup'
 import errorHandler from '../../errorHandler'

--- a/server/utils/azureAppInsights.ts
+++ b/server/utils/azureAppInsights.ts
@@ -1,3 +1,4 @@
+import { randomUUID } from 'node:crypto'
 import {
   Contracts,
   defaultClient,
@@ -7,7 +8,6 @@ import {
   type TelemetryClient,
 } from 'applicationinsights'
 import { Request, RequestHandler } from 'express'
-import { v4 } from 'uuid'
 import { CorrelationContext } from 'applicationinsights/out/AutoCollection/CorrelationContextManager'
 import { EnvelopeTelemetry } from 'applicationinsights/out/Declarations/Contracts'
 import type { ApplicationInfo } from '../applicationInfo'
@@ -109,7 +109,7 @@ export function appInsightsMiddleware(): RequestHandler {
       const context = getCorrelationContext()
       if (context && req.route) {
         context.customProperties.setProperty('operationName', `${req.method} ${req.route?.path}`)
-        context.customProperties.setProperty('operationId', v4())
+        context.customProperties.setProperty('operationId', randomUUID())
       }
     })
     next()

--- a/server/utils/validateUuid.test.ts
+++ b/server/utils/validateUuid.test.ts
@@ -1,0 +1,222 @@
+// ref:
+// https://github.com/uuidjs/uuid/blob/7c1ea087a8149b57380fc8bb7f68c3a215cb6e4b/src/test/test_constants.ts
+
+import { validateUuid } from './validateUuid'
+
+function generateTestData() {
+  const NIL = '00000000-0000-0000-0000-000000000000'
+  const MAX = 'ffffffff-ffff-ffff-ffff-ffffffffffff'
+  const testCases = [
+    // constants
+    { value: NIL, expectedValidate: true },
+    { value: MAX, expectedValidate: true },
+
+    // each version, with either all 0's or all 1's in settable bits
+    {
+      value: '00000000-0000-1000-8000-000000000000',
+      expectedValidate: true,
+    },
+    {
+      value: 'ffffffff-ffff-1fff-8fff-ffffffffffff',
+      expectedValidate: true,
+    },
+    {
+      value: '00000000-0000-2000-8000-000000000000',
+      expectedValidate: true,
+    },
+    {
+      value: 'ffffffff-ffff-2fff-bfff-ffffffffffff',
+      expectedValidate: true,
+    },
+    {
+      value: '00000000-0000-3000-8000-000000000000',
+      expectedValidate: true,
+    },
+    {
+      value: 'ffffffff-ffff-3fff-bfff-ffffffffffff',
+      expectedValidate: true,
+    },
+    {
+      value: '00000000-0000-4000-8000-000000000000',
+      expectedValidate: true,
+    },
+    {
+      value: 'ffffffff-ffff-4fff-bfff-ffffffffffff',
+      expectedValidate: true,
+    },
+    {
+      value: '00000000-0000-5000-8000-000000000000',
+      expectedValidate: true,
+    },
+    {
+      value: 'ffffffff-ffff-5fff-bfff-ffffffffffff',
+      expectedValidate: true,
+    },
+    {
+      value: '00000000-0000-6000-8000-000000000000',
+      expectedValidate: true,
+    },
+    {
+      value: 'ffffffff-ffff-6fff-bfff-ffffffffffff',
+      expectedValidate: true,
+    },
+    {
+      value: '00000000-0000-7000-8000-000000000000',
+      expectedValidate: true,
+    },
+    {
+      value: 'ffffffff-ffff-7fff-bfff-ffffffffffff',
+      expectedValidate: true,
+    },
+    {
+      value: '00000000-0000-8000-8000-000000000000',
+      expectedValidate: true,
+    },
+    {
+      value: 'ffffffff-ffff-8fff-bfff-ffffffffffff',
+      expectedValidate: true,
+    },
+    { value: '00000000-0000-9000-8000-000000000000', expectedValidate: false },
+    { value: 'ffffffff-ffff-9fff-bfff-ffffffffffff', expectedValidate: false },
+    { value: '00000000-0000-a000-8000-000000000000', expectedValidate: false },
+    { value: 'ffffffff-ffff-afff-bfff-ffffffffffff', expectedValidate: false },
+    { value: '00000000-0000-b000-8000-000000000000', expectedValidate: false },
+    { value: 'ffffffff-ffff-bfff-bfff-ffffffffffff', expectedValidate: false },
+    { value: '00000000-0000-c000-8000-000000000000', expectedValidate: false },
+    { value: 'ffffffff-ffff-cfff-bfff-ffffffffffff', expectedValidate: false },
+    { value: '00000000-0000-d000-8000-000000000000', expectedValidate: false },
+    { value: 'ffffffff-ffff-dfff-bfff-ffffffffffff', expectedValidate: false },
+    { value: '00000000-0000-e000-8000-000000000000', expectedValidate: false },
+    { value: 'ffffffff-ffff-efff-bfff-ffffffffffff', expectedValidate: false },
+
+    // selection of normal, valid UUIDs
+    {
+      value: 'd9428888-122b-11e1-b85c-61cd3cbb3210',
+      expectedValidate: true,
+    },
+    {
+      value: '000003e8-2363-21ef-b200-325096b39f47',
+      expectedValidate: true,
+    },
+    {
+      value: 'a981a0c2-68b1-35dc-bcfc-296e52ab01ec',
+      expectedValidate: true,
+    },
+    {
+      value: '109156be-c4fb-41ea-b1b4-efe1671c5836',
+      expectedValidate: true,
+    },
+    {
+      value: '90123e1c-7512-523e-bb28-76fab9f2f73d',
+      expectedValidate: true,
+    },
+    {
+      value: '1ef21d2f-1207-6660-8c4f-419efbd44d48',
+      expectedValidate: true,
+    },
+    {
+      value: '017f22e2-79b0-7cc3-98c4-dc0c0c07398f',
+      expectedValidate: true,
+    },
+    {
+      value: '0d8f23a0-697f-83ae-802e-48f3756dd581',
+      expectedValidate: true,
+    },
+
+    // all variant octet values
+    { value: '00000000-0000-1000-0000-000000000000', expectedValidate: false },
+    { value: '00000000-0000-1000-1000-000000000000', expectedValidate: false },
+    { value: '00000000-0000-1000-2000-000000000000', expectedValidate: false },
+    { value: '00000000-0000-1000-3000-000000000000', expectedValidate: false },
+    { value: '00000000-0000-1000-4000-000000000000', expectedValidate: false },
+    { value: '00000000-0000-1000-5000-000000000000', expectedValidate: false },
+    { value: '00000000-0000-1000-6000-000000000000', expectedValidate: false },
+    { value: '00000000-0000-1000-7000-000000000000', expectedValidate: false },
+    {
+      value: '00000000-0000-1000-8000-000000000000',
+      expectedValidate: true,
+    },
+    {
+      value: '00000000-0000-1000-9000-000000000000',
+      expectedValidate: true,
+    },
+    {
+      value: '00000000-0000-1000-a000-000000000000',
+      expectedValidate: true,
+    },
+    {
+      value: '00000000-0000-1000-b000-000000000000',
+      expectedValidate: true,
+    },
+    { value: '00000000-0000-1000-c000-000000000000', expectedValidate: false },
+    { value: '00000000-0000-1000-d000-000000000000', expectedValidate: false },
+    { value: '00000000-0000-1000-e000-000000000000', expectedValidate: false },
+    { value: '00000000-0000-1000-f000-000000000000', expectedValidate: false },
+
+    // invalid strings
+    { value: '00000000000000000000000000000000', expectedValidate: false }, // unhyphenated NIL
+    { value: '', expectedValidate: false },
+    { value: 'invalid uuid string', expectedValidate: false },
+    {
+      value: '=Y00a-f*vb*-c-d#-p00f\b-g0h-#i^-j*3&-L00k-\nl---00n-fg000-00p-00r+',
+      expectedValidate: false,
+    },
+
+    // invalid types
+    { value: undefined, expectedValidate: false },
+    { value: null, expectedValidate: false },
+    { value: 123, expectedValidate: false },
+    { value: /regex/, expectedValidate: false },
+    { value: new Date(0), expectedValidate: false },
+    { value: false, expectedValidate: false },
+  ]
+
+  // Add NIL and MAX UUIDs with 1-bit flipped in each position
+  for (let charIndex = 0; charIndex < 36; charIndex += 1) {
+    // Skip hyphens and version char
+    if (
+      charIndex === 8 ||
+      charIndex === 13 ||
+      charIndex === 14 || // version char
+      charIndex === 18 ||
+      charIndex === 23
+    ) {
+      // eslint-disable-next-line no-continue
+      continue
+    }
+
+    const nilChars = NIL.split('')
+    const maxChars = MAX.split('')
+
+    for (let i = 0; i < 4; i += 1) {
+      // eslint-disable-next-line no-bitwise
+      nilChars[charIndex] = (0x0 ^ (1 << i)).toString(16)
+      // NIL UUIDs w/ a single 1-bit
+      testCases.push({ value: nilChars.join(''), expectedValidate: false })
+
+      // MAX UUIDs w/ a single 0-bit
+      // eslint-disable-next-line no-bitwise
+      maxChars[charIndex] = (0xf ^ (1 << i)).toString(16)
+      testCases.push({ value: maxChars.join(''), expectedValidate: false })
+    }
+  }
+  return testCases
+}
+
+describe('validateUuid', () => {
+  const testCases = generateTestData()
+
+  it.each(testCases.filter(({ expectedValidate }) => expectedValidate).map(({ value }) => value))(
+    'should allow %j',
+    value => {
+      expect(validateUuid(value)).toBe(true)
+    },
+  )
+
+  it.each(testCases.filter(({ expectedValidate }) => !expectedValidate).map(({ value }) => value))(
+    'should fail %j',
+    value => {
+      expect(validateUuid(value)).toBe(false)
+    },
+  )
+})

--- a/server/utils/validateUuid.ts
+++ b/server/utils/validateUuid.ts
@@ -1,0 +1,13 @@
+// ref:
+// https://github.com/uuidjs/uuid/blob/7c1ea087a8149b57380fc8bb7f68c3a215cb6e4b/src/regex.ts#L1
+// https://github.com/uuidjs/uuid/blob/7c1ea087a8149b57380fc8bb7f68c3a215cb6e4b/src/validate.ts#L3-L5
+import type { UUID } from 'node:crypto'
+
+const regex =
+  /^(?:[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}|00000000-0000-0000-0000-000000000000|ffffffff-ffff-ffff-ffff-ffffffffffff)$/i
+
+/** Checks that a value is a hyphenated UUID hex string, ignoring case */
+// eslint-disable-next-line import/prefer-default-export
+export function validateUuid(uuid: unknown): uuid is UUID {
+  return typeof uuid === 'string' && regex.test(uuid)
+}


### PR DESCRIPTION
…since newer versions do not work with jest/ts-jest due to being ESM-only

---

boo! cypress+webpack aren’t happy using the standard lib uuid generator